### PR TITLE
v0.4.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @angular-package/sass changelog
 
+### v0.4.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.4.1-beta)
+
+- Add `property.variant()` to the `index`. [8c16e87]
+- Fix `class.variant()` by checking `$attribute` against empty `list`. [9280a21]
+- Fix `property.variant()` function by adding arguments to properly call retrieved functions. [96bcb0a]
+- Fix unnecessary imports, and use `property.property()` in `property.variant()`. [213d174]
+
+[9280a21]: https://github.com/angular-package/sass/commit/9280a21be5d222ba5b850ba6a8ec5a3f79920e3a
+[213d174]: https://github.com/angular-package/sass/commit/213d17417cbf7fe94ff522a45221e734751fd228
+[96bcb0a]: https://github.com/angular-package/sass/commit/96bcb0a2f38c4ea0199ed30d694f204b7fd7797c
+[8c16e87]: https://github.com/angular-package/sass/commit/8c16e877f2c1d9bc5161db5b75158b4c7c899368
+
 ### v0.4.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.4.0-beta)
 
 - Add **class** module to handle CSS class selectors(variants). [9a7fed7] [b51b22a] [01c830a] [a2ed250] [c88c00a]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The second, newer, and simplified translator [`v1.0.0`](https://github.com/angul
 
 <br>
 
-Sass extension is **free** to use. If you enjoy it, please consider donating via [`fiat`](https://docs.angular-package.dev/donate/usd-fiat), [Revolut platform](https://business.revolut.com/revolutme/angularpackage) or [`cryptocurrency`](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [`@angular-package`](https://github.com/sponsors/angular-package) for further development. ♥  
+Sass extension is **free** to use. If you enjoy it, please consider donating via [fiat](https://docs.angular-package.dev/donate/usd-fiat), [Revolut platform](https://business.revolut.com/revolutme/angularpackage) or [cryptocurrency](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [@angular-package](https://github.com/sponsors/angular-package) for further development. ♥  
 
 > Feel **free** to submit a pull request. Help is always appreciated.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Sass - extension for sass modules and new modules.
 Extended sass modules:
 
 * The [`sass:color`](https://sass-lang.com/documentation/modules/color/) is extended by [`@angular-package/sass/color`](https://docs.angular-package.dev/v/sass/color/overview) - module generates new colors based on existing ones, making it easy to build color themes.
-<!-- * The [`@angular-package/sass/scheme`](https://) module. -->
-
 * The [`sass:list`](https://sass-lang.com/documentation/modules/list/) is extended by [`@angular-package/sass/list`](https://docs.angular-package.dev/v/sass/list/overview) - module lets you access and modify values in lists.
 * The [`sass:map`](https://sass-lang.com/documentation/modules/map/) is extended by [`@angular-package/sass/map`](https://docs.angular-package.dev/v/sass/map/overview) - module makes it possible to look up the value associated with a key in a map, and much more.
 * The [`sass:math`](https://sass-lang.com/documentation/modules/math/) is extended by [`@angular-package/sass/math`](https://docs.angular-package.dev/v/sass/math/overview) - module provides functions that operate on numbers.
@@ -47,11 +45,22 @@ New modules:
 
 * The [`@angular-package/sass/class`](https://docs.angular-package.dev/v/sass/class/overview) module to handle CSS class selectors(variants).
 * The [`@angular-package/sass/comparison`](https://docs.angular-package.dev/v/sass/comparison/overview) module to compare single or multiple values.
-* The [`@angular-package/sass/function`](https://docs.angular-package.dev/v/sass/function/overview) module function to handle calling functions, especially in a form of `string`.
+* The [`@angular-package/sass/function`](https://docs.angular-package.dev/v/sass/function/overview) module function to handle calling functions, especially in a form of `string` in `list`.
 * The [`@angular-package/sass/property`](https://docs.angular-package.dev/v/sass/property/overview) module to set multiple CSS properties or variants with called functions on values.
 * The [`@angular-package/sass/translator`](https://docs.angular-package.dev/v/sass/translator/overview) module handles global dictionary to translate words.
 * The [`@angular-package/sass/values`](https://docs.angular-package.dev/v/sass/values/overview) module to modify arbitrary values.
-* The [`@angular-package/sass/var`](https://docs.angular-package.dev/v/sass/var/overview) module is designed to handle CSS variables with the use of space-separated words separated by delimiter that can be translated by the dictionary.
+* The [`@angular-package/sass/var`](https://docs.angular-package.dev/v/sass/var/overview) module is designed to handle CSS variables with the use of words that can be translated by the dictionary.
+
+Module moved
+
+* The `@angular-package/sass/number` moved to the [`@angular-package/sass/math`](https://docs.angular-package.dev/v/sass/math/overview) module.
+
+Translator
+
+In the `beta` version, two translators are inside the `translator` folder. First(will be deprecated) `v0.1.0`, the default exported dictionary, was created to pass an external dictionary in some functions to merge with a global dictionary.
+The second, newer, and simplified translator `v1.0.0` is designed with only the global(internal) dictionary, and the external dictionary is passing only in `merge` and `translation`.
+
+<br>
 
 Sass extension is free to use. If you enjoy it, please consider donating via [`fiat`](https://docs.angular-package.dev/donate/usd-fiat) or [`cryptocurrency`](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [`@angular-package`](https://github.com/sponsors/angular-package) for further development. ♥  
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Extended sass modules:
 * The [`sass:selector`](https://sass-lang.com/documentation/modules/selector/) is extended by [`@angular-package/sass/selector`](https://docs.angular-package.dev/v/sass/selector/overview) - module provides access to Sass’s powerful selector engine.
 * The [`sass:string`](https://sass-lang.com/documentation/modules/string/) is extended by [`@angular-package/sass/string`](https://docs.angular-package.dev/v/sass/string/overview) - module makes it easy to combine, search, or split apart strings.
 
+<br>
+
 New modules:
 
 * The [`@angular-package/sass/class`](https://docs.angular-package.dev/v/sass/class/overview) module to handle CSS class selectors(variants).
@@ -51,20 +53,24 @@ New modules:
 * The [`@angular-package/sass/values`](https://docs.angular-package.dev/v/sass/values/overview) module to modify arbitrary values.
 * The [`@angular-package/sass/var`](https://docs.angular-package.dev/v/sass/var/overview) module is designed to handle CSS variables with the use of words that can be translated by the dictionary.
 
-Module moved
+<br>
+
+Module moved:
 
 * The `@angular-package/sass/number` moved to the [`@angular-package/sass/math`](https://docs.angular-package.dev/v/sass/math/overview) module.
 
-Translator
+<br>
 
-In the `beta` version, two translators are inside the `translator` folder. First(will be deprecated) `v0.1.0`, the default exported dictionary, was created to pass an external dictionary in some functions to merge with a global dictionary.
-The second, newer, and simplified translator `v1.0.0` is designed with only the global(internal) dictionary, and the external dictionary is passing only in `merge` and `translation`.
+Translator:
+
+In the `beta` version, two translators are inside the [`translator`](https://github.com/angular-package/sass/tree/main/translator) folder. First(will be deprecated) [`v0.1.0`](https://github.com/angular-package/sass/tree/main/translator/v0.1.0), the default exported dictionary, was created to pass an external dictionary in some functions to merge with a global dictionary.
+The second, newer, and simplified translator [`v1.0.0`](https://github.com/angular-package/sass/tree/main/translator/v1.0.0) is designed with only the global(internal) dictionary, and the external dictionary is passed only in `merge` and `translation`.
 
 <br>
 
-Sass extension is free to use. If you enjoy it, please consider donating via [`fiat`](https://docs.angular-package.dev/donate/usd-fiat) or [`cryptocurrency`](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [`@angular-package`](https://github.com/sponsors/angular-package) for further development. ♥  
+Sass extension is **free** to use. If you enjoy it, please consider donating via [`fiat`](https://docs.angular-package.dev/donate/usd-fiat), [Revolut platform](https://business.revolut.com/revolutme/angularpackage) or [`cryptocurrency`](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [`@angular-package`](https://github.com/sponsors/angular-package) for further development. ♥  
 
-> Feel free to submit a pull request. Help is always appreciated.
+> Feel **free** to submit a pull request. Help is always appreciated.
 
 <br>
 
@@ -172,7 +178,7 @@ MIT © angular-package ([license][sass-license])
 
 <!-- Discord -->
 [discord-badge]: https://img.shields.io/discord/925168966098386944?style=social&logo=discord&label=Discord
-[discord-channel]: https://discord.com/channels/925168966098386944
+[discord-channel]: https://discord.com/invite/rUCR2CW75G
 
 <!-- Gitter -->
 [gitter-badge]: https://img.shields.io/gitter/room/angular-package/ap-sass?style=social&logo=gitter

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ How do I know when to release 1.0.0?
 
 > If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you’re worrying a lot about backwards compatibility, you should probably already be 1.0.0.
 
+<br>
+
 ## License
 
 MIT © angular-package ([license][sass-license])
@@ -163,7 +165,7 @@ MIT © angular-package ([license][sass-license])
 [github-badge-sponsor]: https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&link=https://github.com/sponsors/angular-package
 [github-sponsor-link]: https://github.com/sponsors/angular-package
 [patreon-badge]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-patreon.vercel.app%2Fapi%3Fusername%3Dangularpackage%26type%3Dpatrons&style=flat
-[patreon-link]: https://patreon.com/angularpackage
+[patreon-link]: https://www.patreon.com/join/angularpackage/checkout?fan_landing=true&rid=0
 
 [angulario]: https://angular.io
 [skeleton]: https://github.com/angular-package/skeleton

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The second, newer, and simplified translator [`v1.0.0`](https://github.com/angul
 
 <br>
 
-Sass extension is **free** to use. If you enjoy it, please consider donating via [fiat](https://docs.angular-package.dev/donate/usd-fiat), [Revolut platform](https://business.revolut.com/revolutme/angularpackage) or [cryptocurrency](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [@angular-package](https://github.com/sponsors/angular-package) for further development. ♥  
+Sass extension is **free** to use. If you enjoy it, please consider donating via [fiat](https://docs.angular-package.dev/v/sass/donate/fiat), [Revolut platform](https://business.revolut.com/revolutme/angularpackage) or [cryptocurrency](https://spectrecss.angular-package.dev/donate/thb-cryptocurrency) the [@angular-package](https://github.com/sponsors/angular-package) for further development. ♥  
 
 > Feel **free** to submit a pull request. Help is always appreciated.
 

--- a/class/variant/_variant.mixin.scss
+++ b/class/variant/_variant.mixin.scss
@@ -43,7 +43,7 @@
         @each $attribute, $variant in $attribute-variant {
           @if type-of($attribute) == map {
             @each $key, $value in $attribute { $attribute: nest($key, $value); }
-          } @else if function.has($attribute) {
+          } @else if list.length($attribute) > 0 and function.has($attribute) {
             $attribute: function.call-arglist($attribute...);
           }
           @each $class in if(list.separator($class) == comma, $class, ($class,)) {

--- a/function/call/_call.arglist.function.scss
+++ b/function/call/_call.arglist.function.scss
@@ -1,21 +1,33 @@
 // Sass.
 @use 'sass:list';
+@use 'sass:meta';
 
 // Functions.
-@use '../function.call.function' as *;
+@use '../function.get.function';
 
 // Status: DONE
 // The `call.arglist()` function calls function of `$name` on `$arglist` with a separator comma where elements are arguments or space where the whole
 // list is an argument.
 // @param `$name` Function name to call arguments from `$arglist` as comma-separated arguments or argument.
 // @param `$arglist` List on which to call function of `$name`.
+// @param `$prefix` Allowed prefixes of the function name.
+// @param `$separator` Allowed separators of the function name.
+// @param `$functions` Functions instead of global functions retrieved from `function.$functions`.
+// @param `$function` Parameter to retrieve function from global `function.$functions`.
 // @returns The returned value is the result of invoked function.
-@function arglist($name, $arglist) {
+@function arglist(
+  $name,
+  $arglist,
+  $prefix: null,
+  $separator: null,
+  $functions: null,
+  $function: function.get($name, $prefix, $separator, $functions)
+) {
   @if $name {
     @return if(
       list.separator($arglist) == comma,
-      call($name, $arglist...),
-      call($name, $arglist)
+      meta.call($function, $arglist...),
+      meta.call($function, $arglist)
     );
   }
   @return null;

--- a/function/call/_call.by-list.function.scss
+++ b/function/call/_call.by-list.function.scss
@@ -17,10 +17,18 @@
 // elements are arguments or space where the whole list is an argument.
 // Nested list can contain function name in the first element, then it's used instead of `$function` argument to call following list.
 // @param `$list` List with nested lists on which to call `$function` or function from nested lists.
-// @param `$prefix` Prefix to pick function name from nested lists of `$list`.
-// @param `$function` Function name, with prefix of `$prefix` to call nested list in `$list` as arguments or argument.
+// @param `$prefix` Allowed prefixes to pick function name from nested lists of `$list`.
+// @param `$separator` Allowed separators to pick function name from nested lists of `$list`.
+// @param `$functions` Functions instead of global functions retrieved from `function.$functions`.
+// @param `$execute` Executes the function.
 // @returns The returned value is `$list` with nested lists invoked by function.
-@function by-list($list, $prefix: null, $separator: null, $functions: null, $execute: true) {
+@function by-list(
+  $list,
+  $prefix: null,
+  $separator: null,
+  $functions: null,
+  $execute: true
+) {
   @if type-of($list) == list {
     $result: ();
     $index: 1;
@@ -43,8 +51,12 @@
         );
       }
       @if $function-arguments {
-        $result: list.append($result, call.arglist($function-arguments...), list.separator($list));
-        $list: remove($list, $prefix, $functions);
+        $result: list.append(
+          $result,
+          call.arglist(nth($function-arguments, 1), nth($function-arguments, 2), $prefix, $separator, $functions),
+          list.separator($list)
+        );
+        $list: remove($list, $prefix, $separator, $functions);
       } @else {
         $result: list.append($result, list.nth($list, $index), list.separator($list));
         $index: $index + 1;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.4.0-beta",
+  "version": "0.4.1-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",

--- a/property/_index.scss
+++ b/property/_index.scss
@@ -3,5 +3,4 @@
 @forward 'property.set.mixin';
 @forward 'property.value.function';
 @forward 'property.variables';
-
-// @forward 'property.variant.mixin'; // TODO: bring back
+@forward 'property.variant.mixin';

--- a/property/_property.variant.mixin.scss
+++ b/property/_property.variant.mixin.scss
@@ -6,23 +6,21 @@
 @use 'property.variables' as variables;
 
 // Functions.
-@use 'property.set.mixin' as property;
+@use 'property.mixin' as property;
 
 // Modules.
 @use '../class';
 @use '../meta';
-@use '../selector';
-@use '../values';
 
 // Status: DONE
 // Property `property.variant()` mixin sets property variant.
 // @param `$variant` Variant of map type to set.
 // @param `$important` Indicates property is important.
-// @param `$pseudo-class`
-// @param `$dictionary`
-// @param `$class-function`
-// @param `$functions`
-// @param `$execute`
+// @param `$pseudo-class` Pseudo class for `$variant`.
+// @param `$dictionary` Dictionary to translate class `$variant`.
+// @param `$class-function` Function to set class selector.
+// @param `$functions` Functions to use to call on property values.
+// @param `$execute` Execute `property.property()` function.
 @mixin variant(
   $variant: (),
   $important: null,
@@ -40,7 +38,7 @@
     @include class.variant($variant, $pseudo-class, $dictionary, $class-function, map) using($resolved) {
       @if type-of(map.get($resolved, value)) == map {
         @each $attribute, $value in map.get($resolved, value) {
-          @include property.set(
+          @include property.property(
             (list.join(map.get($resolved, property), map.get($resolved, attribute) $attribute or ()): $value),
             $important,
             $prefix,
@@ -51,9 +49,8 @@
           );
         }
       } @else {
-        @include property.set(
-          (list.join(map.get($resolved, property), map.get($resolved, attribute) or ()):
-          map.get($resolved, value)),
+        @include property.property(
+          (list.join(map.get($resolved, property), map.get($resolved, attribute) or ()): map.get($resolved, value)),
           $important,
           $prefix,
           $separator,

--- a/property/_property.variant.mixin.scss
+++ b/property/_property.variant.mixin.scss
@@ -6,11 +6,12 @@
 @use 'property.variables' as variables;
 
 // Functions.
-@use 'property.mixin' as property;
+@use 'property.set.mixin' as property;
 
 // Modules.
 @use '../class';
 @use '../meta';
+@use '../selector';
 
 // Status: DONE
 // Property `property.variant()` mixin sets property variant.
@@ -38,7 +39,7 @@
     @include class.variant($variant, $pseudo-class, $dictionary, $class-function, map) using($resolved) {
       @if type-of(map.get($resolved, value)) == map {
         @each $attribute, $value in map.get($resolved, value) {
-          @include property.property(
+          @include property.set(
             (list.join(map.get($resolved, property), map.get($resolved, attribute) $attribute or ()): $value),
             $important,
             $prefix,
@@ -49,7 +50,7 @@
           );
         }
       } @else {
-        @include property.property(
+        @include property.set(
           (list.join(map.get($resolved, property), map.get($resolved, attribute) or ()): map.get($resolved, value)),
           $important,
           $prefix,

--- a/property/_property.variant.mixin.spec.scss
+++ b/property/_property.variant.mixin.spec.scss
@@ -13,8 +13,8 @@
 
 
 function.$functions: map.merge(function.$functions, (
-  selector: meta.module-functions("selector"),
-  var: meta.module-functions("var")
+  selector: meta.module-functions(selector),
+  var: meta.module-functions(var)
 ));
 
 property.$type-function: map.merge(property.$type-function, (list: --var-get));
@@ -22,37 +22,43 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 
 // Examples.
 // FEATURE: single variant: (property/class: class/value)
-// @include variant((float: right));
+// @include variant((float: right)); // TODO: use `variant.create()`
+// @include variant((float: (right: right)));
 // .float-right {
 //   float: right;
 // }
 
 // FEATURE: single variant: (property/class: class/value + important)
-// @include variant((float: right '!important'));
+// @include variant((float: right !important));
+// @include variant((float: (right: right !important)));
 // .float-right {
 //   float: right !important;
 // }
 
 // FEATURE: single variant: (property/class: class/value, property/class: class/value) + important + pseudo-class
-// @include variant((float: right), true, (':hover', ':visited'));
+// @include variant((float: right), true, (':hover', ':visited')); // TODO: use `variant.create()`
+// @include variant((float: (right: right)), true, (':hover', ':visited'));
 // .float-right:hover, .float-right:visited {
 //   float: right !important;
 // }
 
 // FEATURE: single variant: (property/class: class/value, property/class: class/value) + important + pseudo-class + dictionary
-// @include variant((float: right), true, (':hover', ':visited'), (float: f, right: r));
+// @include variant((float: right), true, (':hover', ':visited'), (float: f, right: r)); // TODO: use `variant.create()`
+// @include variant((float: (right: right)), true, (':hover', ':visited'), (float: f, right: r));
 // .f-r:hover, .f-r:visited {
 //   float: right !important;
 // }
 
 // FEATURE: single variant: (property/class: class/value + adjust + important, property/class: class/value)
-// @include variant((float: --var-get (right, ('+' 15)) '!important'));
+// @include variant((float: --var-get (right, ('+' 15)) !important)); // TODO: use `variant.create()`
+// @include variant((float: (right: --var-get (right, ('+' 15)) !important)));
 // .float-right {
 //   float: calc(var(--s-right) + 15) !important;
 // }
 
 // FEATURE: multiple variants: (property/class: class/value + important, property/class: class/value)
-// @include variant((float: right '!important', text align: left));
+// @include variant((float: right '!important', text align: left)); // TODO: use `variant.create()`
+// @include variant((float: (right: right !important), text align: (left: left)));
 // .float-right {
 //   float: right !important;
 // }
@@ -61,7 +67,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: (property/class: class/value, class/value)
-// @include variant((float: (right, left)));
+// @include variant((float: (right, left))); // TODO: use `variant.create()`
+// @include variant((float: (right: right, left: left)));
 // .float-right {
 //   float: right;
 // }
@@ -70,7 +77,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: (property/class: class/value, class/value + important)
-// @include variant((float: (right, left !important)));
+// @include variant((float: (right, left !important))); // TODO: use `variant.create()`
+// @include variant((float: (right: right, left: left !important)));
 // .float-right {
 //   float: right;
 // }
@@ -79,7 +87,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: ((property/class, property/class): (class/value, class/value)) + important + pseudo-class
-// @include variant(((float, text align): (right, left)), true, (':hover', ':visited'));
+// @include variant(((float, text align): (right, left)), true, (':hover', ':visited')); // TODO: use `variant.create()`
+// @include variant(((float, text align): (right: right, left: left)), true, (':hover', ':visited'));
 // .float-right:hover, .float-right:visited {
 //   float: right !important;
 // }
@@ -94,7 +103,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: ((property/class, property/class): (class/value, class/value)) + important + pseudo-class + dictionary
-// @include variant(((float, text align): (right, left)), true, ':hover', (float: f));
+// @include variant(((float, text align): (right, left)), true, ':hover', (float: f)); // TODO: use `variant.create()`
+// @include variant(((float, text align): (right: right, left: left)), true, ':hover', (float: f));
 // .f-right:hover {
 //   float: right !important;
 // }
@@ -109,7 +119,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: ((property/class,): (class/value, class/value + important))
-// @include variant(((position,): (absolute, fixed, relative '!important', sticky '!important')));
+// @include variant(((position,): (absolute, fixed, relative !important, sticky !important))); // TODO: use `variant.create()`
+// @include variant(((position,): (absolute: absolute, fixed: fixed, relative: relative !important, sticky: sticky !important)));
 // .position-absolute {
 //   position: absolute;
 // }
@@ -123,7 +134,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 //   position: sticky !important;
 // }
 
-// @include variant(((position,): (absolute '!important', fixed, relative, sticky)));
+// @include variant(((position,): (absolute !important, fixed, relative, sticky))); // TODO: use `variant.create()`
+// @include variant(((position,): (absolute: absolute !important, fixed: fixed, relative: relative, sticky: sticky)));
 // .position-absolute {
 //   position: absolute !important;
 // }
@@ -137,7 +149,8 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 //   position: sticky;
 // }
 
-// @include variant(( flex direction: ( column, row ) ));
+// @include variant(( flex direction: ( column, row ) )); // TODO: use `variant.create()`
+// @include variant(( flex direction: ( column: column, row: row ) ));
 // .flex-direction-column {
 //   flex-direction: column;
 // }
@@ -146,7 +159,7 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // }
 
 // FEATURE: multiple variants: (property/class: (class: value , class: value))
-// @include variant((align items: (center: center, start: flex-start, end: flex-end)));
+// @include variant((align items: (center: center, start: flex-start, end: flex-end))); // TODO: use `variant.create()`
 // .align-items-center {
 //   align-items: center;
 // }

--- a/property/_property.variant.mixin.spec.scss
+++ b/property/_property.variant.mixin.spec.scss
@@ -471,3 +471,36 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // .p-bottom-3:hover {
 //   padding-bottom: var(--s-unit-3);
 // }
+
+// Variant.
+// @include variant((
+//   border: (
+//     (top-left, bottom-right): (
+//       radius: (radius: 5%),
+//     )
+//   ),
+//   scroll: (
+//     ((margin, padding): block): (
+//       start 5: (start: 5%),
+//       end 10: (end: 10%),
+//     )
+//   )
+// ));
+// .border-top-left-radius {
+//   border-top-left-radius: 5%;
+// }
+// .border-bottom-right-radius {
+//   border-bottom-right-radius: 5%;
+// }
+// .scroll-margin-block-start-5 {
+//   scroll-margin-block-start: 5%;
+// }
+// .scroll-margin-block-end-10 {
+//   scroll-margin-block-end: 10%;
+// }
+// .scroll-padding-block-start-5 {
+//   scroll-padding-block-start: 5%;
+// }
+// .scroll-padding-block-end-10 {
+//   scroll-padding-block-end: 10%;
+// }


### PR DESCRIPTION
### v0.4.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.4.1-beta)

- Add `property.variant()` to the `index`. 8c16e87
- Fix `class.variant()` by checking `$attribute` against empty `list`. 9280a21
- Fix `property.variant()` function by adding arguments to properly call retrieved functions. 96bcb0a
- Fix unnecessary imports, and use `property.property()` in `property.variant()`. 213d174
