### PR TITLE
v0.5.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @angular-package/sass changelog
 
+### v0.5.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.5.1-beta)
+
+- Fix `function.call-arglist()` by adding `$arguments` to the `$arglist` by using only `list.append()` function and checking if `$arglist` is space-separated list.
+
 ### v0.5.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.5.0-beta)
 
 - Update `property` module to handle arguments to use `var.get()` function dictionary. [d28f797]

--- a/function/_function.spec.scss
+++ b/function/_function.spec.scss
@@ -116,6 +116,7 @@ var.$var: map.merge(var.$var, (prefix: s, delimiter: '-'));
 // @debug function.call-by-list(5px (var-get primary) 10px (var-get secondary));
 // @debug function.call-by-list(5px (--var-get (unit 1)) 10px (--var-get (unit 5)) 1px 2px);
 // @debug function.call-by-list(((--var-get: (unit 5, 15, rem)) 15px));
+// @debug function.call-by-list((--var-get (unit 5)), $arguments: (dictionary: (unit: u)));
 
 // `function.insert()`
 // @debug function.call-by-list(function.insert((padding, (top, bottom)) (), $type-function: (list: selector-nest)));

--- a/function/call/_call.arglist.function.scss
+++ b/function/call/_call.arglist.function.scss
@@ -30,10 +30,10 @@
 ) {
   @if $name {
     @if $arguments {
-      $arglist: if(
-        meta.type-of($arguments) == map,
-        list.append($arglist, (arguments: $arguments), comma),
-        list.join($arglist, $arguments, comma)
+      $arglist: list.append(
+        if(meta.type-of($arglist) == list and list.separator($arglist) == space, ($arglist,), $arglist),
+        if(meta.type-of($arguments) == map, (arguments: $arguments), $arguments),
+        comma
       );
     }
     @if list.separator($arglist) == comma {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### v0.5.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.5.1-beta)

- Fix `function.call-arglist()` by adding `$arguments` to the `$arglist` by using only `list.append()` function and checking if `$arglist` is space-separated list. fd90100

[fd90100]: https://github.com/angular-package/sass/commit/fd90100e2bca35904c8710c78189fd95aa7fcd0b