### PR TITLE
v0.6.0-beta

### DIFF
--- a/property/_property.variant.mixin.scss
+++ b/property/_property.variant.mixin.scss
@@ -56,7 +56,7 @@
             $type-function,
             $functions,
             $execute,
-            $dictionary
+            (dictionary: $dictionary)
           );
         }
       } @else {
@@ -68,7 +68,7 @@
           $type-function,
           $functions,
           $execute,
-          $dictionary
+          (dictionary: $dictionary)
         );
       }
     }

--- a/property/_property.variant.mixin.spec.scss
+++ b/property/_property.variant.mixin.spec.scss
@@ -516,3 +516,13 @@ property.$type-function: map.merge(property.$type-function, (list: --var-get));
 // .scroll-padding-block-end-10 {
 //   scroll-padding-block-end: 10%;
 // }
+
+// dictionary
+// @include property.variant(
+//   (z-index: (aaa: (primary dark) a)),
+//   true,
+//   (),
+//   (class: (primary: p), var: (primary: n)),
+//   $type-function: (list: --var-get),
+//   $functions: (var: (get: meta.get-function(get, false, var))),
+// );

--- a/selector/_selector.class.function.scss
+++ b/selector/_selector.class.function.scss
@@ -45,6 +45,9 @@
     map.get(get.map($name) or (), dictionary, get.map($name) or ())
   );
 
+  // Retrieve class dictionary if passed.
+  $dictionary: if(map.has-key($dictionary, class), map.get($dictionary, class), $dictionary);
+
   // Name.
   $name: remove.list(remove.list(parent-first(remove.map($name)), $bracketed: only), 0);
 

--- a/var/functions/_var.name.function.scss
+++ b/var/functions/_var.name.function.scss
@@ -18,14 +18,14 @@
 // @returns The return value is CSS variable of `$name`.
 @function name(
   $name,
-  $dictionary: (),
+  $dictionary: null,
   $delimiter: null,
   $prefix: null,
   $suffix: null
 ) {
   @return --#{functions.name(
     $name,
-    $dictionary,
+    if($dictionary and map.has-key($dictionary, var), map.get($dictionary, var), $dictionary) or (),
     $delimiter or map.get(var.$var, delimiter),
     $prefix or map.get(var.$var, prefix),
     $suffix or map.get(var.$var, suffix)
@@ -33,6 +33,7 @@
 }
 
 // Examples.
+// @debug name(layout spacing, null, '-', s); // --s-layout-spacing
 // @debug name(layout spacing, (), '-', s); // --s-layout-spacing
 
 // dictionary
@@ -44,6 +45,7 @@
 // dictionary passed in the name
 // @debug name(layout spacing (layout: lay, spacing: spa), (), '-', s); // --s-lay-spa
 // @debug name(layout spacing (layout: lay, spacing: spa), (prefix: spectre), '-'); // --spectre-lay-spa
+// @debug name(layout spacing (layout: lay, spacing: spa), (var: (prefix: spectre)), '-'); // --spectre-lay-spa
 
 // dictionary with the var key
 // @debug name(layout spacing, (prefix: spectre, suffix: end), '-'); // --spectre-layout-spacing-end


### PR DESCRIPTION
### v0.6.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.6.0-beta)

- Fix `property.variant()` passing `$dictionary` argument by adding map `(dictionary: $dictionary)`. [df48216]
- Update `selector.class()` functionality to retrieve dictionary from `$dictionary` if key `class` is found. [ae518d4]
- Update `var.name()` functionality to retrieve dictionary from `$dictionary` if `var` is found. [f3e5c83]

[f3e5c83]: https://github.com/angular-package/sass/commit/f3e5c8387fc476bc33525bcb7c0fd88e116f0736
[ae518d4]: https://github.com/angular-package/sass/commit/ae518d4f0119f72c89f418fb70e275d86b183307
[df48216]: https://github.com/angular-package/sass/commit/df48216ed068549775da62dd1ba3a0f63d3841d4