### PR TITLE
v0.6.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @angular-package/sass changelog
 
+### v0.6.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.6.1-beta)
+
+- Fix `color.hsla-color()` and `color.retrieve()` by removing `values.map` import and change `values.map` to `list.to-map()`. [e8fe993]
+
+[e8fe993]: https://github.com/angular-package/sass/commit/e8fe99345d70f82bd18d1f12c1a0f50c6ba0b8a1
+
 ### v0.6.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.6.0-beta)
 
 - Fix `property.variant()` passing `$dictionary` argument by adding map `(dictionary: $dictionary)`. [df48216]

--- a/color/functions/_color.hsla-color.function.scss
+++ b/color/functions/_color.hsla-color.function.scss
@@ -3,7 +3,6 @@
 
 // Functions.
 @use '../../map/map.get.function' as map;
-@use '../../values/values.map.function' as values;
 @use 'color.alpha-var.function' as *;
 @use 'color.hue-var.function' as *;
 @use 'color.lightness-var.function' as *;

--- a/color/functions/_color.retrieve.function.scss
+++ b/color/functions/_color.retrieve.function.scss
@@ -1,6 +1,3 @@
-// Functions.
-@use '../../values/values.map.function';
-
 // Modules.
 @use '../../list';
 
@@ -25,7 +22,7 @@
   @if list.length($name) > 4 {
     $attributes: list.insert-nth($attributes, 2, (saturation: number list, (saturation lightness alpha: number list): map));
   }
-  @return values.map(
+  @return list.to-map(
     $name,
     (name: list string),
     $attributes...
@@ -33,27 +30,27 @@
 }
 
 // Examples.
-// @debug get(primary); // (name: primary)
-// @debug get(primary dark); // (name: primary dark)
+// @debug retrieve(primary); // (name: primary)
+// @debug retrieve(primary dark); // (name: primary dark)
 
 // comma separator
 // length 1 lightness
-// @debug get((primary dark, 50%)); // (name: primary dark, lightness: 50%)
+// @debug retrieve((primary dark, 50%)); // (name: primary dark, lightness: 50%)
 
 // length 2 lightness, alpha
-// @debug get((primary dark, 50%, 0.5)); // (name: primary dark, lightness: 50%, alpha: 0.5)
+// @debug retrieve((primary dark, 50%, 0.5)); // (name: primary dark, lightness: 50%, alpha: 0.5)
 
 // length > 2
-// @debug get((primary dark, 50deg, 5%, 3%)); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%)
-// @debug get((primary dark, 50deg, 5%, 3%, 0.9)); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%, alpha: 0.9)
+// @debug retrieve((primary dark, 50deg, 5%, 3%)); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%)
+// @debug retrieve((primary dark, 50deg, 5%, 3%, 0.9)); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%, alpha: 0.9)
 
 // without comma separator
-// @debug get((primary dark) 50%); // (name: primary dark, lightness: 50%)
-// @debug get((primary dark) 50% 0.5); // (name: primary dark, lightness: 50%, alpha: 0.5)
-// @debug get((primary dark) 50deg 5% 3%); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%)
-// @debug get((primary dark) 50deg 5% 3% 0.9); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%, alpha: 0.9)
+// @debug retrieve((primary dark) 50%); // (name: primary dark, lightness: 50%)
+// @debug retrieve((primary dark) 50% 0.5); // (name: primary dark, lightness: 50%, alpha: 0.5)
+// @debug retrieve((primary dark) 50deg 5% 3%); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%)
+// @debug retrieve((primary dark) 50deg 5% 3% 0.9); // (name: primary dark, hue: 50deg, saturation: 5%, lightness: 3%, alpha: 0.9)
 
-// @debug get((primary dark) ('*' 50%)); // (name: primary dark, lightness: "*" 50%)
-// @debug get((primary dark, ('*' 50%), ('/' 0.5))); // (name: primary dark, lightness: "*" 50%, alpha: "/" 0.5)
-// @debug get((primary dark, ('*' 5deg), ('*' 2%), ('*' 15%))); // (name: primary dark, hue: "*" 5deg, saturation: "*" 2%, lightness: "*" 15%)
-// @debug get((primary dark, ('*' 5deg), ('*' 2%), ('*' 15%), ('*' 0.5))); // (name: primary dark, hue: "*" 5deg, saturation: "*" 2%, lightness: "*" 15%, alpha: "*" 0.5)
+// @debug retrieve((primary dark) ('*' 50%)); // (name: primary dark, lightness: "*" 50%)
+// @debug retrieve((primary dark, ('*' 50%), ('/' 0.5))); // (name: primary dark, lightness: "*" 50%, alpha: "/" 0.5)
+// @debug retrieve((primary dark, ('*' 5deg), ('*' 2%), ('*' 15%))); // (name: primary dark, hue: "*" 5deg, saturation: "*" 2%, lightness: "*" 15%)
+// @debug retrieve((primary dark, ('*' 5deg), ('*' 2%), ('*' 15%), ('*' 0.5))); // (name: primary dark, hue: "*" 5deg, saturation: "*" 2%, lightness: "*" 15%, alpha: "*" 0.5)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.6.0-beta",
+  "version": "0.6.1-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### v0.6.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.6.1-beta)

- Fix `color.hsla-color()` and `color.retrieve()` by removing `values.map` import and change `values.map` to `list.to-map()`. [e8fe993]

[e8fe993]: https://github.com/angular-package/sass/commit/e8fe99345d70f82bd18d1f12c1a0f50c6ba0b8a1