### PR TITLE
v0.9.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @angular-package/sass changelog
 
+### v0.9.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.1-beta)
+
+- Fix by adding `media` to ng-package assets. [5da60de]
+
+[5da60de]: https://github.com/angular-package/sass/commit/5da60de6ae46298a4ee083e656aaa42989a9b3bd
+
 ### v0.9.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.0-beta)
 
 - Update [`var.set()`](https://github.com/angular-package/sass/blob/main/var/mixins/_var.set.mixin.scss) add `$dictionary` argument to translate CSS variable names. [99647c2]

--- a/ng-package.json
+++ b/ng-package.json
@@ -13,6 +13,7 @@
     "./list/**/*.scss",
     "./map/**/*.scss",
     "./math/**/*.scss",
+    "./media/**/*.scss",
     "./meta/**/*.scss",
     "./number/**/*.scss",
     "./object/**/*.scss",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.9.0-beta",
+  "version": "0.9.1-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### v0.9.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.1-beta)

- Fix by adding `media` to ng-package assets. [5da60de]

[5da60de]: https://github.com/angular-package/sass/commit/5da60de6ae46298a4ee083e656aaa42989a9b3bd