### PR TITLE
v0.9.4-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @angular-package/sass changelog
 
+- Fix `color` module mixins `color.background-color()`, `color.background()`, and `color.color()` by removing `$selector` argument not in use. [8884903]
+
+[8884903]: https://github.com/angular-package/sass/commit/888490353c3831e66d604f2c5a6d0763e73e9526
+
 ### v0.9.3-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.3-beta)
 
 - Fix [`color/mixins`](https://github.com/angular-package/sass/tree/main/color/mixins) by using function from functions and update imports. [159a652]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @angular-package/sass changelog
 
+### v0.9.4-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.4-beta)
+
 - Fix `color` module mixins `color.background-color()`, `color.background()`, and `color.color()` by removing `$selector` argument not in use. [8884903]
 
 [8884903]: https://github.com/angular-package/sass/commit/888490353c3831e66d604f2c5a6d0763e73e9526

--- a/color/mixins/_color.background-color.mixin.scss
+++ b/color/mixins/_color.background-color.mixin.scss
@@ -10,7 +10,6 @@
 // @param `$alpha`
 // @param `$fallback`
 // @param `$important`
-// @param `$selector`
 // @param `$dictionary`
 @mixin background-color(
   $color,
@@ -20,7 +19,6 @@
   $alpha: null,
   $fallback: null,
   $important: false,
-  $selector: null,
   $dictionary: (),
 ) {
   @include color(
@@ -31,8 +29,7 @@
     $alpha,
     $fallback,
     $important,
-    $selector,
-    $dictionary
+    $dictionary,
   );
 }
 

--- a/color/mixins/_color.background.mixin.scss
+++ b/color/mixins/_color.background.mixin.scss
@@ -10,7 +10,6 @@
 // @param `$alpha`
 // @param `$fallback`
 // @param `$important`
-// @param `$selector`
 // @param `$dictionary`
 @mixin background(
   $color,
@@ -31,19 +30,19 @@
     $alpha,
     $fallback,
     $important,
-    $selector,
     $dictionary,
   );
 }
 
 // Examples.
 // :host {
-  // @include background(primary dark);
+//   @include background(primary dark);
 
-  // @include background((
-  //   dark: (code, -42.5%),
-  //   light: (code, 42.5%),
-  //   normal: (code, 42.5%),
-  // ));
+//   @include background((
+//     dark: (code, -42.5%),
+//     light: (code, 42.5%),
+//     normal: (code, 42.5%),
+//   ));
 
+//   @include background(primary dark, $dictionary: (primary: p));
 // }

--- a/color/mixins/_color.color.mixin.scss
+++ b/color/mixins/_color.color.mixin.scss
@@ -18,7 +18,6 @@
 // @param `$alpha`
 // @param `$fallback`
 // @param `$important`
-// @param `$selector`
 // @param `$dictionary`
 // @param `$property`
 @mixin color(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.9.3-beta",
+  "version": "0.9.4-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### v0.9.4-beta [#](https://github.com/angular-package/sass/releases/tag/v0.9.4-beta)

- Fix `color` module mixins `color.background-color()`, `color.background()`, and `color.color()` by removing `$selector` argument not in use. [8884903]

[8884903]: https://github.com/angular-package/sass/commit/888490353c3831e66d604f2c5a6d0763e73e9526