### PR TITLE
v0.11.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @angular-package/sass changelog
 
+### v0.11.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.11.1-beta)
+
+- Update [`color.variant()`](https://github.com/angular-package/sass/blob/main/color/mixins/_color.variant.mixin.scss) use `$modifier` argument in the `class.variant()`. [dd72913]
+
+[dd72913]: https://github.com/angular-package/sass/commit/dd729133d09d7d9f581ece14ce7388dbcb2c457c
+
 ### v0.11.0-beta [#](https://github.com/angular-package/sass/releases/tag/v0.11.0-beta)
 
 - Add new [`variant`](https://github.com/angular-package/sass/tree/develop/variant) module to handle variants. [a7a8c1c]

--- a/color/mixins/_color.variant.mixin.scss
+++ b/color/mixins/_color.variant.mixin.scss
@@ -41,6 +41,7 @@
   $dictionary: (),
   $property: null,
   $function: meta.get-function(class),
+  $modifier: null,
 ) {
   $variant-property: null;
 
@@ -56,7 +57,7 @@
   $max-count: if($variant-property and list.separator($variant-property) == comma, list.length($variant-property), 0);
   $count: 0;
 
-  @include class.variant($variant, $pseudo-class, $dictionary, $function, map) using($resolved) {
+  @include class.variant($variant, $pseudo-class, $dictionary, $function, map, $modifier) using($resolved) {
     $attribute: map.get($resolved, attribute);
     $color: map.get($resolved, value);
     $-property: if(meta.type-of($property) == map, map.get($property, name), $property) or map.get($resolved, property) or color;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@angular-package/sass",
   "description": "Extension for sass modules and new modules.",
-  "version": "0.11.0-beta",
+  "version": "0.11.1-beta",
   "main": "./index.scss",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### v0.11.1-beta [#](https://github.com/angular-package/sass/releases/tag/v0.11.1-beta)

- Update [`color.variant()`](https://github.com/angular-package/sass/blob/main/color/mixins/_color.variant.mixin.scss) to use `$modifier` argument in the `class.variant()`. [dd72913]

[dd72913]: https://github.com/angular-package/sass/commit/dd729133d09d7d9f581ece14ce7388dbcb2c457c